### PR TITLE
Automate Abstract and Declaration pages

### DIFF
--- a/Ch1-Intro.tex
+++ b/Ch1-Intro.tex
@@ -27,3 +27,42 @@ Reference example \cite{Abreu:2010}.
  cell7 & cell8 & cell9 \\ 
  \hline
 \end{labelledTable}
+
+\begin{minted}[
+frame=leftline,
+framesep=2mm,
+baselinestretch=1.1,
+bgcolor=LightGray,
+fontsize=\footnotesize,
+linenos
+]{python}
+import numpy as np
+    
+def incmatrix(genl1,genl2):
+    m = len(genl1)
+    n = len(genl2)
+    M = None #to become the incidence matrix
+    VT = np.zeros((n*m,1), int)  #dummy variable
+    
+    #compute the bitwise xor matrix
+    M1 = bitxormatrix(genl1)
+    M2 = np.triu(bitxormatrix(genl2),1) 
+
+    for i in range(m-1):
+        for j in range(i+1, m):
+            [r,c] = np.where(M2 == M1[i,j])
+            for k in range(len(r)):
+                VT[(i)*n + r[k]] = 1;
+                VT[(i)*n + c[k]] = 1;
+                VT[(j)*n + r[k]] = 1;
+                VT[(j)*n + c[k]] = 1;
+                
+                if M is None:
+                    M = np.copy(VT)
+                else:
+                    M = np.concatenate((M, VT), 1)
+                
+                VT = np.zeros((n*m,1), int)
+    
+    return M
+\end{minted}

--- a/Ch1-Intro.tex
+++ b/Ch1-Intro.tex
@@ -9,3 +9,21 @@
 
 
 Reference example \cite{Abreu:2010}.
+
+\begin{markdown}
+
+## A Markdown Heading
+
+- **bold text**
+- *italic text*
+- [A link](https://shu.ac.uk/)
+
+\end{markdown}
+
+\begin{labelledTable}{LabelledTable}{|c|c|c|}
+ \hline
+ cell1 & cell2 & cell3 \\ 
+ cell4 & cell5 & cell6 \\ 
+ cell7 & cell8 & cell9 \\ 
+ \hline
+\end{labelledTable}

--- a/PhDThesisPSnPDF.cls
+++ b/PhDThesisPSnPDF.cls
@@ -634,6 +634,7 @@ supported!}
     bookmarksnumbered=true,
     breaklinks=true,
     linktocpage,
+    linktoc=all,
     colorlinks=true,
     linkcolor=black,
     urlcolor=black,
@@ -671,6 +672,7 @@ supported!}
     bookmarksnumbered=true,
     breaklinks=true,
     linktocpage,
+    linktoc = all,
     colorlinks=true,
     linkcolor=blue,
     urlcolor=blue,
@@ -1163,7 +1165,7 @@ Director(s) of Studies:
 }
 % Abstract content appears here
 {
-\\
+\par
 \noindent
 \textit{Keywords}:
 \@keywords \\
@@ -1282,10 +1284,10 @@ Director(s) of Studies:
     \end{center}
   }{
     % college is defined
-    \begin{minipage}[b]{0.54\textwidth}
+    \begin{minipage}[b]{0.69\textwidth}
       \flushleft\@college
     \end{minipage}
-    \begin{minipage}[b]{0.44\textwidth}
+    \begin{minipage}[b]{0.29\textwidth}
       \flushright \@degreedate
     \end{minipage}
   } % college is defined

--- a/PhDThesisPSnPDF.cls
+++ b/PhDThesisPSnPDF.cls
@@ -862,6 +862,10 @@ wish to left align your text}
 \newcommand{\@degreedate}{\monthname[\the\month]\space\the\year}
 \newcommand{\degreedate}[1]{\renewcommand{\@degreedate}{#1}}
 
+% The subject of the award
+\newcommand{\@awardsubject}{\hl{SET awardsubject}}
+\newcommand{\awardsubject}[1]{\renewcommand{\@awardsubject}{#1}}
+
 % The full (unabbreviated) name of the degree
 \newcommand{\@degreetitle}{}
 \newcommand{\degreetitle}[1]{\renewcommand{\@degreetitle}{#1}}
@@ -875,7 +879,7 @@ wish to left align your text}
 \newcommand{\college}[1]{\renewcommand{\@college}{#1}}
 
 % The name of your University
-\newcommand{\@university}{}
+\newcommand{\@university}{\hl{SET university}}
 \newcommand{\university}[1]{\renewcommand{\@university}{#1}}
 
 % Defining the crest
@@ -910,7 +914,7 @@ wish to left align your text}
 
 % keywords (These keywords will appear in the PDF meta-information
 % called `pdfkeywords`.)
-\newcommand{\@keywords}{}
+\newcommand{\@keywords}{-}
 \newcommand{\keywords}[1]{\renewcommand{\@keywords}{#1}}
 
 % subjectline (This subject will appear in the PDF meta-information
@@ -934,6 +938,28 @@ wish to left align your text}
 \fi
 }
 
+\newcommand{\detailtexcount}[1]{%
+  \immediate\write18{texcount -merge -sum -q -utf8 #1.tex output.bbl > #1.wcdetail }%
+  \verbatiminput{#1.wcdetail}%
+}
+
+\newcommand{\quickwordcount}[1]{%
+  \immediate\write18{texcount -1 -merge -sum -q -utf8 #1.tex output.bbl > #1-words.sum }%
+  \input{#1-words.sum} words%
+}
+
+% The word count of the document
+% reference: https://www.overleaf.com/learn/how-to/Is_there_a_way_to_run_a_word_count_that_doesn%27t_include_LaTeX_commands%3F
+\newcommand{\@wordcount}{\quickwordcount{thesis}\space}
+\newcommand{\wordcount}[1]{\renewcommand{\@wordcount}{#1}}
+
+% The supervisors displayed in the abstract.
+\newcommand{\@supervisoryteam}{\hl{SET supervisoryteam}}
+\newcommand{\supervisoryteam}[1]{\renewcommand{\@supervisoryteam}{#1}}
+
+%The director(s) of study in the declaration
+\newcommand{\@directors}{\hl{SET directors}}
+\newcommand{\directors}[1]{\renewcommand{\@directors}{#1}}
 
 % ******************************************************************************
 % *************************** Front Matter Layout ******************************
@@ -1007,6 +1033,20 @@ wish to left align your text}
 \end{singlespace}
 }
 
+% Declaration %
+
+\newenvironment{declaration}{}{
+    \vspace{5cm}
+\fbox{\fbox { \parbox { .9\linewidth} {
+Name: \@author \\
+Date: \today \\
+Award:
+\@awardsubject \\
+Director(s) of Studies:
+    \@directors
+}}}
+}
+
 % ****************************** Acknowledgements ********************************
 % The acknowledgements environment puts a large, bold, centered
 % "Acknowledgements" label at the top of the page.
@@ -1016,9 +1056,10 @@ wish to left align your text}
 \setsinglecolumn
 \chapter*{\centering \Large Acknowledgements}
 \thispagestyle{empty}
+\begin{center}
+}{
+    \end{center}
 }
-
-
 
 % ******************************* Nomenclature *********************************
 \RequirePackage[intoc]{nomencl}
@@ -1119,7 +1160,22 @@ wish to left align your text}
   \thispagestyle{empty}
  
 \fi
-
+}
+% Abstract content appears here
+{
+\\
+\noindent
+\textit{Keywords}:
+\@keywords \\
+\vspace{3cm}
+\begin{center}
+    \textbf{A thesis submitted in partial fulfilment of the requirements of \@university\space for the degree of\space\@degreetitle}\\
+    \vspace{2cm}
+        \textbf{\@author}\\
+    \vspace{2cm}
+    \textbf {Supervisory team:}
+    \@supervisoryteam \\
+\end{center}
 }
 
 
@@ -1226,10 +1282,10 @@ wish to left align your text}
     \end{center}
   }{
     % college is defined
-    \begin{minipage}[b]{0.49\textwidth}
+    \begin{minipage}[b]{0.54\textwidth}
       \flushleft\@college
     \end{minipage}
-    \begin{minipage}[b]{0.49\textwidth}
+    \begin{minipage}[b]{0.44\textwidth}
       \flushright \@degreedate
     \end{minipage}
   } % college is defined

--- a/PhDThesisPSnPDF.cls
+++ b/PhDThesisPSnPDF.cls
@@ -3,7 +3,7 @@
 \newcommand\fileversion{2.2.2}
 \newcommand\filedate{2016/10/20}
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{PhDThesisPSnPDF}[\filedate\space A PhD thesis class file (v\fileversion)]
+\ProvidesClass{PhDThesisPSnPDF}[\filedate\space A thesis class file (v\fileversion)]
 
 % ******************************************************************************
 % **************************** Class Definition ********************************
@@ -187,8 +187,7 @@ footnotes.}
 \DeclareOption{a4paper}{\renewcommand\PHD@papersize{a4paper}}
 \DeclareOption{a5paper}{\renewcommand\PHD@papersize{a5paper}}
 \DeclareOption{letterpaper}{
-  \ClassWarning{PhDThesisPSnPDF}{The University of Cambridge
-    PhD thesis guidelines recommend using A4 or A5paper}
+  \ClassWarning{PhDThesisPSnPDF}{The university thesis guidelines recommend using A4 or A5paper}
   \renewcommand\PHD@papersize{letterpaper}
 }
 
@@ -940,6 +939,17 @@ wish to left align your text}
 \fi
 }
 
+% The supervisors displayed in the abstract.
+\newcommand{\@supervisoryteam}{\hl{SET supervisoryteam}}
+\newcommand{\supervisoryteam}[1]{\renewcommand{\@supervisoryteam}{#1}}
+
+%The director(s) of study in the declaration
+\newcommand{\@directors}{\hl{SET directors}}
+\newcommand{\directors}[1]{\renewcommand{\@directors}{#1}}
+
+% ******************************************************************************
+% The word count of the document
+% reference: https://www.overleaf.com/learn/how-to/Is_there_a_way_to_run_a_word_count_that_doesn%27t_include_LaTeX_commands%3F
 \newcommand{\detailtexcount}[1]{%
   \immediate\write18{texcount -merge -sum -q -utf8 #1.tex output.bbl > #1.wcdetail }%
   \verbatiminput{#1.wcdetail}%
@@ -950,18 +960,27 @@ wish to left align your text}
   \input{#1-words.sum} words%
 }
 
-% The word count of the document
-% reference: https://www.overleaf.com/learn/how-to/Is_there_a_way_to_run_a_word_count_that_doesn%27t_include_LaTeX_commands%3F
 \newcommand{\@wordcount}{\quickwordcount{thesis}\space}
 \newcommand{\wordcount}[1]{\renewcommand{\@wordcount}{#1}}
 
-% The supervisors displayed in the abstract.
-\newcommand{\@supervisoryteam}{\hl{SET supervisoryteam}}
-\newcommand{\supervisoryteam}[1]{\renewcommand{\@supervisoryteam}{#1}}
+% ******************************************************************************
+% Make tables easier
+\newenvironment{labelledTable}[2]
+{
+\begin{table}
+\caption{#1}
+\begin{center}
+\begin{tabular}{ #2 }
+}{
+    \end{tabular}
+\end{center}
+\end{table}
+}
 
-%The director(s) of study in the declaration
-\newcommand{\@directors}{\hl{SET directors}}
-\newcommand{\directors}[1]{\renewcommand{\@directors}{#1}}
+
+% ******************************************************************************
+
+
 
 % ******************************************************************************
 % *************************** Front Matter Layout ******************************

--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 # SheffieldHallam-PGR-Template
 LaTeX template for PGR final document (thesis) for Sheffield Hallam University research students.
 
-- thesis-info.tex: <Degree Name> should be replaced by your degree name. <Title: A template for research degree thesis at Sheffield Hallam University> should be replaced by your title. <Author> should be replaced by your name.
-- thesis.tex: remove the commenst of %\listoffigures and %\listoftables once you have Tables and Figures. Add a file acknowledgement.tex and remove comment from %\include{acknowledgement} to add. Create an individual file to each chapter.
-- preamble.tex: add any library in here.
-- abstract.tex: do not forget to edit
-- bibliography.bib: your list of references goes here
+- **thesis-info.tex:** 
+  - `<Degree Name>` should be replaced by your degree name. 
+  - `<Title: A template for research degree thesis at Sheffield Hallam University>` should be replaced by your title.
+  - `<Author>` should be replaced by your full name.
+  - `<Keywords>` should be replaced by a comma-separated list of your thesis keywords.
+  - `<Dept>` should be replaced by your department name.
+  - `<Subject>` should be replaced by the subject your degree will be awarded in.
+  - `<Supervisors>` should be replaced by the names of the members of your supervisory team.
+  - `<Directors>` should be replaced by the names of your directors of studies.
+- **thesis.tex:**
+  - remove the commenst of %\listoffigures and %\listoftables once you have Tables and Figures.
+  - Remove comment from %\include{acknowledgement} to add it to your output.
+  - Create an individual file for each chapter.
+- **preamble.tex:** add any library in here.
+- **abstract.tex:** do not forget to edit.
+- **acknowledgement.tex:** do not forget to edit.
+- **declaration.tex:** likely will not need editing. use `\wordcount` to override the automatic value.
+- **bibliography.bib:** your list of references goes here

--- a/abstract.tex
+++ b/abstract.tex
@@ -1,16 +1,4 @@
-
 \begin{abstract}
-The abstract goes here.\\
-
-    \noindent
-    \textit{Keywords}: list of keywords.
+    %%Your abstract goes here
+    \hl{Your abstract goes here.}
 \end{abstract}
-
-\vspace{3cm}
-\begin{center}
-\textbf{A thesis submitted in partial fulfilment of the requirements of Sheffield Hallam University for the degree of <name>}\\
-\vspace{2cm}
-\textbf {Author}\\
-\vspace{2cm}
-{\textbf {Supervisory team:} Prof. A.B. Supervisor, Prof. G.H. Supervisor}    
-\end{center}

--- a/acknowledgement.tex
+++ b/acknowledgement.tex
@@ -1,0 +1,4 @@
+\begin{acknowledgements}
+    %%Your acknowledgements go here
+    \hl{Thank you to...}
+\end{acknowledgements}

--- a/declaration.tex
+++ b/declaration.tex
@@ -1,27 +1,21 @@
-
-
-I hereby declare that:
-\begin{enumerate}
-    \item I have not been enrolled for another award of the University, or other
-academic or professional organisation, whilst undertaking my research
-degree.
-    \item None of the material contained in the thesis has been used in any other
-submission for an academic award.
-    \item I am aware of and understand the University's policy on plagiarism and
-certify that this thesis is my own work. The use of all published or other
-sources of material consulted have been properly and fully
-acknowledged.
-    \item The work undertaken towards the thesis has been conducted in
-accordance with the SHU Principles of Integrity in Research and the
-SHU Research Ethics Policy.
-    \item The word count of the thesis is XXXXX
-\end{enumerate}
-
-\vspace{5cm}
-
-\fbox{\fbox { \parbox { .9\linewidth} {
-Name: \\
-Date: \today \\
-Award: Computing and Informatics\\
-Director(s) of Studies: \\ sup1 \\ sup2\\
-}}}
+\begin{declaration}
+    I hereby declare that:
+    \begin{enumerate}
+        \item I have not been enrolled for another award of the University, or other
+    academic or professional organisation, whilst undertaking my research
+    degree.
+        \item None of the material contained in the thesis has been used in any other
+    submission for an academic award.
+        \item I am aware of and understand the University's policy on plagiarism and
+    certify that this thesis is my own work. The use of all published or other
+    sources of material consulted have been properly and fully
+    acknowledged.
+        \item The work undertaken towards the thesis has been conducted in
+    accordance with the SHU Principles of Integrity in Research and the
+    SHU Research Ethics Policy.
+        \item The word count of the thesis is
+        \makeatletter
+        \@wordcount
+        \makeatother.
+    \end{enumerate}
+\end{declaration}

--- a/preamble.tex
+++ b/preamble.tex
@@ -113,6 +113,8 @@
 
 %%For code synax highlighting
 \usepackage{minted}
+\usepackage{xcolor} % to access the named colour LightGray
+\definecolor{LightGray}{gray}{0.75}
 
 % *****************************************************************************
 % *************************** Bibliography  and References ********************

--- a/preamble.tex
+++ b/preamble.tex
@@ -48,7 +48,6 @@
 
 %\usepackage{algpseudocode}
 
-
 % ********************Captions and Hyperreferencing / URL **********************
 
 % Captions: This makes captions of figures use a boldfaced small font.
@@ -104,6 +103,11 @@
 %\widowpenalty=500
 
 %\usepackage[perpage]{footmisc} %Range of footnote options
+
+%% For highlighting text
+\usepackage{soul}
+%%For counting words
+\usepackage{verbatim}
 
 
 % *****************************************************************************

--- a/preamble.tex
+++ b/preamble.tex
@@ -108,7 +108,8 @@
 \usepackage{soul}
 %%For counting words
 \usepackage{verbatim}
-
+%%For writing in markdown. Ref: https://www.overleaf.com/learn/how-to/Writing_Markdown_in_LaTeX_Documents
+\use{markdown}
 
 % *****************************************************************************
 % *************************** Bibliography  and References ********************

--- a/preamble.tex
+++ b/preamble.tex
@@ -111,6 +111,9 @@
 %%For writing in markdown. Ref: https://www.overleaf.com/learn/how-to/Writing_Markdown_in_LaTeX_Documents
 \use{markdown}
 
+%%For code synax highlighting
+\usepackage{minted}
+
 % *****************************************************************************
 % *************************** Bibliography  and References ********************
 

--- a/thesis-info.tex
+++ b/thesis-info.tex
@@ -1,39 +1,55 @@
 % ************************ Thesis Information & Meta-data **********************
 %% The title of the thesis
-\title{Title: A template for research degree thesis at Sheffield Hallam University}
+\title{<Title: A template for research degree thesis at Sheffield Hallam University>}
+
+%%Keywords
+\keywords{<Keywords>}
+
 %\texorpdfstring is used for PDF metadata. Usage:
 %\texorpdfstring{LaTeX_Version}{PDF Version (non-latex)} eg.,
 %\texorpdfstring{$sigma$}{sigma}
 
 %% Subtitle (Optional)
-%\subtitle{Using the CUED template}
+%\subtitle{Using NodeRED}
 
 %% The full name of the author
-\author{Author}
+\author{<Author>}
 
-%% Department (eg. Department of Engineering, Maths, Physics)
-%\dept{Department of Engineering}
+%% Department (eg. Computing, Engineering, Maths, Physics)
+\dept{<Dept>}
 
 %% University and Crest
 \university{Sheffield Hallam University}
+
 % Crest minimum should be 30mm.
 \crest{\includegraphics[width=0.4\textwidth]{SHU_crest.jpg}}
 %% Use this crest, if you are using the college crest
-%% Crest long miminum should be 65mm
+%% Crest long minimum should be 65mm
 %\crest{\includegraphics[width=0.45\textwidth]{University_Crest_Long}}
 
 %% College shield [optional] 
 % Crest minimum should be 30mm.
 %\collegeshield{\includegraphics[width=0.2\textwidth]{CollegeShields/Kings}}
 
-%% Full title of the Degree
-\degreetitle{Degree Name}
-
+% Award subject (Computer Science, Software Engineering, Biology, etc)
+\awardsubject{<Subject>}
+%% You can also set the full title of the Degree
+\degreetitle{<Degree Name>}
 
 %% College affiliation (optional)
-%\college{King's College}
+%\college{Business, Technology \& Engineering}
 
 %% Submission date
 % Default is set as {\monthname[\the\month]\space\the\year}
 %\degreedate{September 2014} 
 
+%% Overwrite the automatic word count
+%% You can use "TC:ignore" and "TC:endignore" to remove sections from the count
+%% By default references are not included
+%\wordcount{123}
+
+%% Supervisor(s) displayed in the Abstract
+\supervisoryteam{<Supervisors>}
+
+%%Director(s) of studies on the declaration
+\directors{<Directors>}


### PR DESCRIPTION
I have updated the abstract and declaration environments in PhDThesisPSnPDF.cls to enable the following changes:

* **Abstract:**
    - ​All content after "Keywords:" is automatically populated from thesis-info.tex - keywords, university name, degree title, author, supervisory team.
* **Declaration:**
    -  Now auto-fills author, award subject and director of studies from thesis-info.tex variables.
    - The enumerated list includes an automatic wordcount using the `texcount` package that can be overwritten with `\wordcount` in thesis-info.tex.
* **Table of Contents:**
    - Make each item clickable to link to the relevant section of the document
* **General:**
    - Added highlighting for missing variables, using `soul` package.
    - ​Updated readme

​
​Checked on overleaf.com
   ​

